### PR TITLE
do not specify illegal fields to FilterExpression

### DIFF
--- a/tests/test_archive_querier.py
+++ b/tests/test_archive_querier.py
@@ -229,6 +229,7 @@ def test_paginate_work_id_records(table_maker, querier):
         cursor = page.cursor
         if cursor is None:
             break
+
     assert len(results) == 150
 
 


### PR DESCRIPTION
Despite the behavior of dynamodb local, real dynamodb does not
allow you to specify primary keys or range keys to a
FilterExpression.