### PR TITLE
add http url to api v0

### DIFF
--- a/tests/test_archive_querier.py
+++ b/tests/test_archive_querier.py
@@ -37,7 +37,14 @@ class HttpResults(list):
     def _validate_response(self):
         for k in ['next', 'records']:
             assert k in self.response
+        for r in self.response['records']:
+            self._validate_record(r)
+
         self._validate_next_url(self.response['next'])
+
+    def _validate_record(self, record):
+        assert 'http_url' in record
+        assert record['http_url'].endswith(record['metadata']['id'] + '/data')
 
     def _validate_next_url(self, next):
         if next is None:


### PR DESCRIPTION
Some users will want s3 urls to benefit from existing s3 support
and s3's more vast read/write capacity. Others will want http
urls because they don't speak s3 or don't have suitable
credentials.