### PR TITLE
add queries for latest files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from moto import mock_dynamodb2
 
 from datalake_api import app as datalake_api
 from datalake_common.tests import *  # noqa
+from datalake_common import DatalakeRecord
 
 
 @pytest.fixture
@@ -141,3 +142,10 @@ def table_maker(request, dynamodb):
         return table
 
     return maker
+
+
+def create_test_records(bucket='datalake-test', **kwargs):
+    m = random_metadata()
+    m.update(**kwargs)
+    url = 's3://' + bucket + '/' + '/'.join([str(v) for v in kwargs.values()])
+    return DatalakeRecord.list_from_metadata(url, m)


### PR DESCRIPTION
Users often need to retrieve the latest file for a given where
and what. This is a quick solution that hides what these users
are currently doing behind the API. It's not perfect, of
course. It only looks back 14 days for the latest file. But it's
a start. And if this turns out to be insufficient, we can add
something bigger and better (e.g., a cache of recent files,
another dynamodb index, etc.)