### PR TITLE
QUERIER: default metadata end value is None

### DIFF
--- a/datalake_api/querier.py
+++ b/datalake_api/querier.py
@@ -164,6 +164,9 @@ class QueryResults(list):
         for extra in ['create_time', 'size']:
             if extra in result:
                 r[extra] = result[extra]
+
+        # make sure metadata has an 'end' key
+        r['metadata'].setdefault('end', None)
         return r
 
 

--- a/tests/test_archive_querier.py
+++ b/tests/test_archive_querier.py
@@ -395,6 +395,7 @@ def test_no_end(table_maker, querier, s3_file_from_metadata):
     table_maker(records)
     results = querier.query_by_time(m['start'], m['start'] + 1, m['what'])
     assert len(results) == 1
+    assert results[0]['metadata']['end'] is None
 
 
 def test_no_end_exclusion(table_maker, querier, s3_file_from_metadata):


### PR DESCRIPTION
Here's a follow up to our recent discussion in case we decide it's preferable to gate at the API instead of in datalake-common